### PR TITLE
BAAS-30359: update axios test endpoint

### DIFF
--- a/snippets/functions/third-party/axios.js
+++ b/snippets/functions/third-party/axios.js
@@ -1,7 +1,10 @@
 exports = async function () {
   const axios = require("axios").default;
-  const response = await axios.get("https://api.github.com/users/octocat", {
-    headers: { "Content-Type": "application/json" },
-  });
-  return response.data.login;
+  const response = await axios.get(
+    "https://jsonplaceholder.typicode.com/posts/2",
+    {
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+  return response.data.userId;
 };


### PR DESCRIPTION
Update the test endpoint to use one with less aggressive rate limiting. The GitHub url previously has a low limit for non-authenticated request.

Also updated the BAAS [test](https://github.com/10gen/baas/pull/14405/files) to use this new endpoint.