### PR TITLE
Fix prod workflow

### DIFF
--- a/.github/workflows/zip-and-upload-to-s3-production.yml
+++ b/.github/workflows/zip-and-upload-to-s3-production.yml
@@ -1,9 +1,9 @@
-name: Zip and Upload to S3 for Development
+name: Zip and Upload to S3 for Production
 
 on:
   push:
     branches:
-      - production
+      - main
 
 jobs:
   deploy-after-testing:

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
       "metadata": "/snippets/triggers/project/manifest.json"
     }
   ],
-  "version": "7e5bf28650dfc9e8d3981859adeaa8525fdb2034"
+  "version": "33962567db27d1f4ec53ce4b3813b0dc8754f632"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
       "metadata": "/snippets/triggers/project/manifest.json"
     }
   ],
-  "version": "7bd6521bcefa9ffb7dcfb7ad653044950d6027d1"
+  "version": "be56f0b0146663d7bd6bdb0572bff43a36c4f44f"
 }


### PR DESCRIPTION
The github workflow for production appears to be pointing to the wrong branch `production` instead of `main` and the label for the workflow should have `production`. 