### PR TITLE
BAAS-34841

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
       "metadata": "/snippets/triggers/project/manifest.json"
     }
   ],
-  "version": "783a865c20468d5ca200226c848f45d8fb7ea8a9"
+  "version": "b4ac5b28cf2d12b34580a283ecc810712d23fe52"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
       "metadata": "/snippets/triggers/project/manifest.json"
     }
   ],
-  "version": "f5f7a372e1794e9c4c6fc20650e6f8ad12884ace"
+  "version": "f6cdf7da31b27ebd5213eb948a98e1506377dec9"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
       "metadata": "/snippets/triggers/project/manifest.json"
     }
   ],
-  "version": "b4ac5b28cf2d12b34580a283ecc810712d23fe52"
+  "version": "f5f7a372e1794e9c4c6fc20650e6f8ad12884ace"
 }

--- a/snippets/triggers/match/manifest.json
+++ b/snippets/triggers/match/manifest.json
@@ -7,7 +7,7 @@
       "id": "ed4b3598-6800-413f-9158-d9b1b2a2a081",
       "title": "Update",
       "snippet": "/update.json",
-      "description": "This trigger will only execute if the `storeLocation` array has changed to \"East Langley\" and the \"storeItems\" field has been removed."
+      "description": "This trigger will execute if the `storeLocation` array is updated to include \"East Langley\", the \"storeItems\" field has been removed, and the status field is updated to \"updated\""
     },
     {
       "id": "ed4b3598-6800-413f-9158-d9b1b2a2a082",

--- a/snippets/triggers/match/update.json
+++ b/snippets/triggers/match/update.json
@@ -1,4 +1,5 @@
 {
   "updateDescription.removedFields.0.0": "storeItems",
-  "updateDescription.updatedFields.storeLocation.0.0": "East Langley"
+  "updateDescription.updatedFields.storeLocation.0.0": "East Langley",
+  "updateDescription.updatedFields.status": "updated"
 }

--- a/snippets/triggers/match/update.json
+++ b/snippets/triggers/match/update.json
@@ -1,4 +1,4 @@
 {
   "updateDescription.removedFields.0.0": "storeItems",
-  "updateDescription.updateFields.storeLocation.0.0": "East Langley"
+  "updateDescription.updatedFields.storeLocation.0.0": "East Langley"
 }

--- a/snippets/triggers/project/update.json
+++ b/snippets/triggers/project/update.json
@@ -2,7 +2,7 @@
   "operationType": {
     "$numberInt": "1"
   },
-  "updateDescription.updateFields.storeLocation": {
+  "updateDescription.updatedFields.storeLocation": {
     "$numberInt": "1"
   }
 }


### PR DESCRIPTION
[BAAS-34841](https://jira.mongodb.org/browse/BAAS-34841)

I fixed the project and match update examples to use the correct `updatedFields` field. 

## Question:
There was also a suggestion to use an example of the match update expression (not for arrays). Should we do this or disregard for now? The argument is that it may not be clear for the user that you can update an array or a field directly.

something like this
{
  "updateDescription.removedFields.0.0": "storeItems",
  "updateDescription.updatedFields.storeLocation.0.0": "East Langley",
  "updateDescription.updatedFields.status": "updated"
}